### PR TITLE
Implement confirmation dialog for deleting items

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,21 @@ Install the extension from here: https://extensions.gnome.org/extension/4839/cli
 
 ## Install from source
 
+### Build
+
 ```shell
 cd ~/.local/share/gnome-shell/extensions/ && \
-  git clone git@github.com:SUPERCILEX/gnome-clipboard-history.git clipboard-history@alexsaveau.dev && \
+  git clone https://github.com/SUPERCILEX/gnome-clipboard-history.git clipboard-history@alexsaveau.dev && \
   cd clipboard-history@alexsaveau.dev && \
-  make && gnome-extensions enable clipboard-history@alexsaveau.dev
+  make
+```
+
+### Restart GNOME
+
+<kbd>Alt</kbd> + <kbd>F2</kbd> then type `r`.
+
+### Install
+
+```shell
+gnome-extensions enable clipboard-history@alexsaveau.dev
 ```

--- a/extension.js
+++ b/extension.js
@@ -488,7 +488,7 @@ class ClipboardIndicator extends PanelMenu.Button {
 
     // Move to front (end of list)
     (entry.favorite ? this.entries : this.favoriteEntries).append(entry);
-    this._confirmRemoveEntry(entry);
+    this._removeEntry(entry);
     entry.favorite = !entry.favorite;
     this._addEntry(entry, wasSelected, false, 0);
     this._maybeRestoreMenuPages();

--- a/extension.js
+++ b/extension.js
@@ -53,6 +53,8 @@ let ENABLE_KEYBINDING;
 let PRIVATE_MODE;
 let NOTIFY_ON_COPY;
 let CONFIRM_ON_CLEAR;
+let CONFIRM_REMOVE_FAVORITE;
+let CONFIRM_REMOVE_NON_FAVORITE;
 let MAX_TOPBAR_LENGTH;
 let TOPBAR_DISPLAY_MODE; // 0 - only icon, 1 - only clipboard content, 2 - both, 3 - none
 let DISABLE_DOWN_ARROW;
@@ -486,7 +488,7 @@ class ClipboardIndicator extends PanelMenu.Button {
 
     // Move to front (end of list)
     (entry.favorite ? this.entries : this.favoriteEntries).append(entry);
-    this._removeEntry(entry);
+    this._confirmRemoveEntry(entry);
     entry.favorite = !entry.favorite;
     this._addEntry(entry, wasSelected, false, 0);
     this._maybeRestoreMenuPages();
@@ -565,6 +567,27 @@ class ClipboardIndicator extends PanelMenu.Button {
     }
   }
 
+  _confirmRemoveEntry(entry, fullyDelete, humanGenerated) {
+    if (( entry.favorite && CONFIRM_REMOVE_FAVORITE ) || ( !entry.favorite && CONFIRM_REMOVE_NON_FAVORITE ) ) {
+      const title = _('Delete Entry?');
+      const message = _('Are you sure you want to delete this entry?');
+      const sub_message = _('This operation cannot be undone.');
+
+      ConfirmDialog.openConfirmDialog(
+        title,
+        message,
+        sub_message,
+        _('Delete'),
+        _('Cancel'),
+        () => {
+          this._removeEntry(entry, fullyDelete, humanGenerated);
+        },
+      );
+    } else {
+      this._removeEntry(entry, fullyDelete, humanGenerated);
+    }
+  }
+
   _pruneOldestEntries() {
     let entry = this.entries.head;
     while (
@@ -573,7 +596,7 @@ class ClipboardIndicator extends PanelMenu.Button {
         this.entries.bytes > MAX_BYTES)
     ) {
       const next = entry.next;
-      this._removeEntry(entry, true);
+      this._confirmRemoveEntry(entry, true);
       entry = next;
     }
 
@@ -847,7 +870,7 @@ class ClipboardIndicator extends PanelMenu.Button {
           last.text.endsWith(text) ||
           last.text.startsWith(text))
       ) {
-        this._removeEntry(last, true);
+        this._confirmRemoveEntry(last, true);
       }
     });
   }
@@ -981,7 +1004,7 @@ class ClipboardIndicator extends PanelMenu.Button {
   }
 
   _deleteEntryAndRestoreLatest(entry) {
-    this._removeEntry(entry, true, true);
+    this._confirmRemoveEntry(entry, true, true);
 
     if (!this.currentlySelectedEntry) {
       const nextEntry = this.entries.last();
@@ -1059,6 +1082,12 @@ class ClipboardIndicator extends PanelMenu.Button {
     NOTIFY_ON_COPY = Prefs.Settings.get_boolean(Prefs.Fields.NOTIFY_ON_COPY);
     CONFIRM_ON_CLEAR = Prefs.Settings.get_boolean(
       Prefs.Fields.CONFIRM_ON_CLEAR,
+    );
+    CONFIRM_REMOVE_FAVORITE = Prefs.Settings.get_boolean(
+      Prefs.Fields.CONFIRM_REMOVE_FAVORITE,
+    );
+    CONFIRM_REMOVE_NON_FAVORITE = Prefs.Settings.get_boolean(
+      Prefs.Fields.CONFIRM_REMOVE_NON_FAVORITE,
     );
     ENABLE_KEYBINDING = Prefs.Settings.get_boolean(
       Prefs.Fields.ENABLE_KEYBINDING,

--- a/prefs.js
+++ b/prefs.js
@@ -15,6 +15,8 @@ var Fields = {
   CACHE_ONLY_FAVORITES: 'cache-only-favorites',
   NOTIFY_ON_COPY: 'notify-on-copy',
   CONFIRM_ON_CLEAR: 'confirm-clear',
+  CONFIRM_REMOVE_FAVORITE: 'confirm-remove-favorite',
+  CONFIRM_REMOVE_NON_FAVORITE: 'confirm-remove-non-favorite',
   MOVE_ITEM_FIRST: 'move-item-first',
   ENABLE_KEYBINDING: 'enable-keybindings',
   TOPBAR_PREVIEW_SIZE: 'topbar-preview-size',
@@ -84,6 +86,8 @@ class Prefs extends GObject.Object {
     this.field_cache_disable = new Gtk.Switch();
     this.field_notification_toggle = new Gtk.Switch();
     this.field_confirm_clear_toggle = new Gtk.Switch();
+    this.field_confirm_remove_favorite_toggle = new Gtk.Switch();
+    this.field_confirm_remove_non_favorite_toggle = new Gtk.Switch();
     this.field_strip_text = new Gtk.Switch();
     this.field_paste_on_selection = new Gtk.Switch();
     this.field_process_primary_selection = new Gtk.Switch();
@@ -152,6 +156,16 @@ class Prefs extends GObject.Object {
     });
     let confirmClearLabel = new Gtk.Label({
       label: _('Ask for confirmation before clearing history'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let confirmRemoveFavoriteLabel = new Gtk.Label({
+      label: _('Ask for confirmation before removing favorite entry'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
+    let confirmRemoveNonFavoriteLabel = new Gtk.Label({
+      label: _('Ask for confirmation before removing non-favorite entry'),
       hexpand: true,
       halign: Gtk.Align.START,
     });
@@ -232,6 +246,8 @@ class Prefs extends GObject.Object {
     addRow(topbarPreviewLabel, this.field_topbar_preview_size);
     addRow(notificationLabel, this.field_notification_toggle);
     addRow(confirmClearLabel, this.field_confirm_clear_toggle);
+    addRow(confirmRemoveFavoriteLabel, this.field_confirm_remove_favorite_toggle);
+    addRow(confirmRemoveNonFavoriteLabel, this.field_confirm_remove_non_favorite_toggle);
     addRow(keybindingLabel, this.field_keybinding_activation);
     addRow(null, this.field_keybinding);
 
@@ -268,6 +284,18 @@ class Prefs extends GObject.Object {
     Settings.bind(
       Fields.CONFIRM_ON_CLEAR,
       this.field_confirm_clear_toggle,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    Settings.bind(
+      Fields.CONFIRM_REMOVE_FAVORITE,
+      this.field_confirm_remove_favorite_toggle,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    Settings.bind(
+      Fields.CONFIRM_REMOVE_NON_FAVORITE,
+      this.field_confirm_remove_non_favorite_toggle,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );

--- a/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
@@ -74,6 +74,22 @@
       </description>
     </key>
 
+    <key name="confirm-remove-favorite" type="b">
+      <default>true</default>
+      <summary>Show confirmation dialog on removal of favorite entry</summary>
+      <description>
+        If true, a confirmation dialog is shown when attempting to remove a favorite entry.
+      </description>
+    </key>
+
+    <key name="confirm-remove-non-favorite" type="b">
+      <default>true</default>
+      <summary>Show confirmation dialog on removal of non-favorite entry</summary>
+      <description>
+        If true, a confirmation dialog is shown when attempting to remove a non-favorite entry.
+      </description>
+    </key>
+
     <key name="strip-text" type="b">
       <default>false</default>
       <summary>Remove whitespace around copied plaintext items</summary>


### PR DESCRIPTION
Addresses #109

## Changes

- Added 2 entry deletion confirmation dialog toggles, one for favorite entries, and the other for non-favorite entries. Both toggles are enabled by default.
- Improved "install from source" instructions; not everyone has ssh access to the repository, and GNOME needs to be reloaded after the `make` step, otherwise `gnome-extensions enable clipboard-history@alexsaveau.dev` would not work.

## Help wanted

- Fixing the language locales
- Phrasing of the confirmation dialog messages