### PR TITLE
Improve clarity of install from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,21 @@ Install the extension from here: https://extensions.gnome.org/extension/4839/cli
 
 ## Install from source
 
+### Build
+
 ```shell
 cd ~/.local/share/gnome-shell/extensions/ && \
-  git clone git@github.com:SUPERCILEX/gnome-clipboard-history.git clipboard-history@alexsaveau.dev && \
+  git clone https://github.com/SUPERCILEX/gnome-clipboard-history.git clipboard-history@alexsaveau.dev && \
   cd clipboard-history@alexsaveau.dev && \
-  make && gnome-extensions enable clipboard-history@alexsaveau.dev
+  make
+```
+
+### Restart GNOME
+
+<kbd>Alt</kbd> + <kbd>F2</kbd> then type `r`.
+
+### Install
+
+```shell
+gnome-extensions enable clipboard-history@alexsaveau.dev
 ```


### PR DESCRIPTION
## Changes

- Improved "install from source" instructions; not everyone has ssh access to the repository, and GNOME needs to be reloaded after the `make` step, otherwise `gnome-extensions enable clipboard-history@alexsaveau.dev` would not work.