### PR TITLE
metadata: mark 44 as a supported version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
   "uuid": "clipboard-history@alexsaveau.dev",
   "description": "Gnome Clipboard History is a Gnome extension that saves items you've copied into an easily accessible, searchable history panel.",
   "url": "https://github.com/SUPERCILEX/gnome-clipboard-history",
-  "shell-version": ["40", "41", "42", "43"]
+  "shell-version": ["40", "41", "42", "43", "44"]
 }


### PR DESCRIPTION
I'm using GNOME 44 beta (44~beta-1ubuntu1 on Ubuntu 23.04 with Wayland) and it looks like everything seems working fine after having forced version 44 support in metadata.js.

So I guess we can simply update the metadata.js to allow this nice add-on to run on newer GNOME versions.