### PR TITLE
Disable notifications for "Do Not Disturb" and "Private" modes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1011,7 +1011,7 @@ class ClipboardIndicator extends PanelMenu.Button {
   _showNotification(title, message, transformFn) {
     const dndOn = () =>
       !Main.panel.statusArea.dateMenu._indicator._settings.get_boolean(
-        "show-banners",
+        'show-banners',
       );
     if (PRIVATE_MODE || dndOn()) {
       return;

--- a/extension.js
+++ b/extension.js
@@ -1011,8 +1011,10 @@ class ClipboardIndicator extends PanelMenu.Button {
   _showNotification(title, message, transformFn) {
     this._initNotifSource();
 
+    let DO_NOT_DISTURB_MODE = (!Main.panel.statusArea.dateMenu._indicator._settings.get_boolean('show-banners'));
+
     let notification;
-    if (this._notifSource.count === 0) {
+    if (this._notifSource.count === 0 && !PRIVATE_MODE && !DO_NOT_DISTURB_MODE) {
       notification = new MessageTray.Notification(
         this._notifSource,
         title,

--- a/extension.js
+++ b/extension.js
@@ -1009,15 +1009,19 @@ class ClipboardIndicator extends PanelMenu.Button {
   }
 
   _showNotification(title, message, transformFn) {
-    const dndOn = () => !Main.panel.statusArea.dateMenu._indicator._settings.get_boolean('show-banners');
-    if (PRIVATE_MODE || dndOn()) {
-      return;
-    }
-
     this._initNotifSource();
 
+    let DO_NOT_DISTURB_MODE =
+      !Main.panel.statusArea.dateMenu._indicator._settings.get_boolean(
+        "show-banners",
+      );
+
     let notification;
-    if (this._notifSource.count === 0) {
+    if (
+      this._notifSource.count === 0 &&
+      !PRIVATE_MODE &&
+      !DO_NOT_DISTURB_MODE
+    ) {
       notification = new MessageTray.Notification(
         this._notifSource,
         title,

--- a/extension.js
+++ b/extension.js
@@ -1010,7 +1010,7 @@ class ClipboardIndicator extends PanelMenu.Button {
 
   _showNotification(title, message, transformFn) {
     const dndOn = () => !Main.panel.statusArea.dateMenu._indicator._settings.get_boolean('show-banners');
-    if (PRIVATE_MODE || dndOn) {
+    if (PRIVATE_MODE || dndOn()) {
       return;
     }
 

--- a/extension.js
+++ b/extension.js
@@ -1009,19 +1009,15 @@ class ClipboardIndicator extends PanelMenu.Button {
   }
 
   _showNotification(title, message, transformFn) {
+    const dndOn = () => !Main.panel.statusArea.dateMenu._indicator._settings.get_boolean('show-banners');
+    if (PRIVATE_MODE || dndOn()) {
+      return;
+    }
+
     this._initNotifSource();
 
-    let DO_NOT_DISTURB_MODE =
-      !Main.panel.statusArea.dateMenu._indicator._settings.get_boolean(
-        "show-banners",
-      );
-
     let notification;
-    if (
-      this._notifSource.count === 0 &&
-      !PRIVATE_MODE &&
-      !DO_NOT_DISTURB_MODE
-    ) {
+    if (this._notifSource.count === 0) {
       notification = new MessageTray.Notification(
         this._notifSource,
         title,

--- a/extension.js
+++ b/extension.js
@@ -1009,7 +1009,10 @@ class ClipboardIndicator extends PanelMenu.Button {
   }
 
   _showNotification(title, message, transformFn) {
-    const dndOn = () => !Main.panel.statusArea.dateMenu._indicator._settings.get_boolean('show-banners');
+    const dndOn = () =>
+      !Main.panel.statusArea.dateMenu._indicator._settings.get_boolean(
+        "show-banners",
+      );
     if (PRIVATE_MODE || dndOn()) {
       return;
     }

--- a/extension.js
+++ b/extension.js
@@ -1009,12 +1009,15 @@ class ClipboardIndicator extends PanelMenu.Button {
   }
 
   _showNotification(title, message, transformFn) {
+    const dndOn = () => !Main.panel.statusArea.dateMenu._indicator._settings.get_boolean('show-banners');
+    if (PRIVATE_MODE || dndOn) {
+      return;
+    }
+
     this._initNotifSource();
 
-    let DO_NOT_DISTURB_MODE = (!Main.panel.statusArea.dateMenu._indicator._settings.get_boolean('show-banners'));
-
     let notification;
-    if (this._notifSource.count === 0 && !PRIVATE_MODE && !DO_NOT_DISTURB_MODE) {
+    if (this._notifSource.count === 0) {
       notification = new MessageTray.Notification(
         this._notifSource,
         title,


### PR DESCRIPTION
Add additional checks for displaying notifications.
Don't show them with activated "Do Not Disturb" and/or "Private" modes.
"Do Not Disturb" is a GNOME setting, "Private mode" - extensions setting.

Closes #134