### PR TITLE
Port to ESM / GNOME 45 Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MODULES = metadata.json extension.js store.js dataStructures.js confirmDialog.js prefs.js stylesheet.css LICENSE README.md schemas/
+MODULES = metadata.json extension.js store.js dataStructures.js confirmDialog.js prefs.js settingsFields.js stylesheet.css LICENSE README.md schemas/
 INSTALLPATH = ~/.local/share/gnome-shell/extensions/clipboard-history@alexsaveau.dev/
 
 all: compile-locales compile-settings

--- a/confirmDialog.js
+++ b/confirmDialog.js
@@ -1,11 +1,12 @@
-'use strict';
+import Clutter from 'gi://Clutter';
+import St from 'gi://St';
+import GObject from 'gi://GObject';
 
-const { St, GObject, Clutter } = imports.gi;
-const ModalDialog = imports.ui.modalDialog;
+import * as ModalDialog from 'resource:///org/gnome/shell/ui/modalDialog.js';
 
 let _openDialog;
 
-function openConfirmDialog(
+export function openConfirmDialog(
   title,
   message,
   sub_message,

--- a/dataStructures.js
+++ b/dataStructures.js
@@ -4,7 +4,7 @@
 var TYPE_TEXT = 'text';
 
 // Creates a new `Iterator` for looping over the `List`.
-class Iterator {
+export class Iterator {
   constructor(item) {
     this.item = item;
   }
@@ -21,7 +21,7 @@ class Iterator {
 // Creates a new `Item`:
 // An item is a bit like DOM node: It knows only about its "parent" (`list`),
 // the item before it (`prev`), and the item after it (`next`).
-var LLNode = class Item {
+export var LLNode = class Item {
   // Prepends the given item *before* the item operated on.
   prepend(item) {
     const list = this.list;
@@ -234,7 +234,7 @@ LLNode.prototype.next = LLNode.prototype.prev = LLNode.prototype.list = null;
 // last (`tail`) items.
 // Each item (e.g. `head`, `tail`, &c.) knows which item comes before or after
 // it (its more like the implementation of the DOM in JavaScript).
-var LinkedList = class List {
+export var LinkedList = class List {
   // Creates a new list from the arguments (each a list item) passed in.
   static of(...items) {
     return appendAll(new this(), items);
@@ -365,7 +365,7 @@ LinkedList.prototype.length = 0;
 LinkedList.prototype.tail = LinkedList.prototype.head = null;
 
 // Creates a new list from the items passed in.
-function appendAll(list, items) {
+export function appendAll(list, items) {
   let index;
   let item;
   let iterator;

--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
   "uuid": "clipboard-history@alexsaveau.dev",
   "description": "Gnome Clipboard History is a Gnome extension that saves items you've copied into an easily accessible, searchable history panel.",
   "url": "https://github.com/SUPERCILEX/gnome-clipboard-history",
-  "shell-version": ["40", "41", "42", "43", "44"]
+  "shell-version": ["45"]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,8 @@
   "name": "Clipboard History",
   "version": 26,
   "uuid": "clipboard-history@alexsaveau.dev",
+  "gettext-domain": "clipboard-history@alexsaveau.dev",
+  "settings-schema": "org.gnome.shell.extensions.clipboard-history",
   "description": "Gnome Clipboard History is a Gnome extension that saves items you've copied into an easily accessible, searchable history panel.",
   "url": "https://github.com/SUPERCILEX/gnome-clipboard-history",
   "shell-version": ["45"]

--- a/prefs.js
+++ b/prefs.js
@@ -1,40 +1,24 @@
-'use strict';
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
+import Gio from 'gi://Gio';
+import Adw from 'gi://Adw';
 
-const { GObject, Gtk, Gio } = imports.gi;
+import {
+  ExtensionPreferences,
+  gettext as _,
+} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import Fields from './settingsFields.js';
 
-const Gettext = imports.gettext;
-const _ = Gettext.domain(Me.uuid).gettext;
+export default class Prefs extends ExtensionPreferences {
+  // fillPreferencesWindow() is passed a Adw.PreferencesWindow,
+  // we need to wrap our widget in a Adw.PreferencesPage and Adw.PreferencesGroup
+  // ourselves.
+  // It would be great to port the preferences to standard Adw widgets.
+  // https://gjs.guide/extensions/development/preferences.html#prefs-js
+  fillPreferencesWindow(window) {
+    this.settings = this.getSettings();
 
-var Fields = {
-  HISTORY_SIZE: 'history-size',
-  WINDOW_WIDTH_PERCENTAGE: 'window-width-percentage',
-  CACHE_FILE_SIZE: 'cache-size',
-  CACHE_ONLY_FAVORITES: 'cache-only-favorites',
-  NOTIFY_ON_COPY: 'notify-on-copy',
-  CONFIRM_ON_CLEAR: 'confirm-clear',
-  MOVE_ITEM_FIRST: 'move-item-first',
-  ENABLE_KEYBINDING: 'enable-keybindings',
-  TOPBAR_PREVIEW_SIZE: 'topbar-preview-size',
-  TOPBAR_DISPLAY_MODE_ID: 'display-mode',
-  DISABLE_DOWN_ARROW: 'disable-down-arrow',
-  STRIP_TEXT: 'strip-text',
-  PRIVATE_MODE: 'private-mode',
-  PASTE_ON_SELECTION: 'paste-on-selection',
-  PROCESS_PRIMARY_SELECTION: 'process-primary-selection',
-};
-
-const SCHEMA_NAME = 'org.gnome.shell.extensions.clipboard-history';
-var Settings = ExtensionUtils.getSettings(SCHEMA_NAME);
-
-function init() {
-  ExtensionUtils.initTranslations(Me.uuid);
-}
-
-class Prefs extends GObject.Object {
-  _init() {
     this.main = new Gtk.Grid({
       margin_top: 10,
       margin_bottom: 10,
@@ -88,34 +72,34 @@ class Prefs extends GObject.Object {
     this.field_paste_on_selection = new Gtk.Switch();
     this.field_process_primary_selection = new Gtk.Switch();
     this.field_move_item_first = new Gtk.Switch();
-    this.field_keybinding = createKeybindingWidget(Settings);
+    this.field_keybinding = createKeybindingWidget(this.settings);
     addKeybinding(
       this.field_keybinding.model,
-      Settings,
+      this.settings,
       'toggle-menu',
       _('Toggle the menu'),
     );
     addKeybinding(
       this.field_keybinding.model,
-      Settings,
+      this.settings,
       'clear-history',
       _('Clear history'),
     );
     addKeybinding(
       this.field_keybinding.model,
-      Settings,
+      this.settings,
       'prev-entry',
       _('Previous entry'),
     );
     addKeybinding(
       this.field_keybinding.model,
-      Settings,
+      this.settings,
       'next-entry',
       _('Next entry'),
     );
     addKeybinding(
       this.field_keybinding.model,
-      Settings,
+      this.settings,
       'toggle-private-mode',
       _('Toggle private mode'),
     );
@@ -235,90 +219,98 @@ class Prefs extends GObject.Object {
     addRow(keybindingLabel, this.field_keybinding_activation);
     addRow(null, this.field_keybinding);
 
-    Settings.bind(
+    this.settings.bind(
       Fields.HISTORY_SIZE,
       this.field_size,
       'value',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.WINDOW_WIDTH_PERCENTAGE,
       this.window_width_percentage,
       'value',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.CACHE_FILE_SIZE,
       this.field_cache_size,
       'value',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.CACHE_ONLY_FAVORITES,
       this.field_cache_disable,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.NOTIFY_ON_COPY,
       this.field_notification_toggle,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.CONFIRM_ON_CLEAR,
       this.field_confirm_clear_toggle,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.MOVE_ITEM_FIRST,
       this.field_move_item_first,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.TOPBAR_DISPLAY_MODE_ID,
       this.field_display_mode,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.DISABLE_DOWN_ARROW,
       this.field_disable_down_arrow,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.TOPBAR_PREVIEW_SIZE,
       this.field_topbar_preview_size,
       'value',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.STRIP_TEXT,
       this.field_strip_text,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.PASTE_ON_SELECTION,
       this.field_paste_on_selection,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.PROCESS_PRIMARY_SELECTION,
       this.field_process_primary_selection,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );
-    Settings.bind(
+    this.settings.bind(
       Fields.ENABLE_KEYBINDING,
       this.field_keybinding_activation,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );
+
+    const group = new Adw.PreferencesGroup();
+    group.add(this.main);
+
+    const page = new Adw.PreferencesPage();
+    page.add(group);
+
+    window.add(page);
   }
 
   _create_display_mode_options() {
@@ -337,13 +329,6 @@ class Prefs extends GObject.Object {
     }
     return liststore;
   }
-}
-
-const PrefsObj = new GObject.registerClass(Prefs);
-
-function buildPrefsWidget() {
-  let widget = new PrefsObj();
-  return widget.main;
 }
 
 //binding widgets

--- a/settingsFields.js
+++ b/settingsFields.js
@@ -1,0 +1,18 @@
+const SettingsFields = {
+  HISTORY_SIZE: 'history-size',
+  WINDOW_WIDTH_PERCENTAGE: 'window-width-percentage',
+  CACHE_FILE_SIZE: 'cache-size',
+  CACHE_ONLY_FAVORITES: 'cache-only-favorites',
+  NOTIFY_ON_COPY: 'notify-on-copy',
+  CONFIRM_ON_CLEAR: 'confirm-clear',
+  MOVE_ITEM_FIRST: 'move-item-first',
+  ENABLE_KEYBINDING: 'enable-keybindings',
+  TOPBAR_PREVIEW_SIZE: 'topbar-preview-size',
+  TOPBAR_DISPLAY_MODE_ID: 'display-mode',
+  DISABLE_DOWN_ARROW: 'disable-down-arrow',
+  STRIP_TEXT: 'strip-text',
+  PRIVATE_MODE: 'private-mode',
+  PASTE_ON_SELECTION: 'paste-on-selection',
+  PROCESS_PRIMARY_SELECTION: 'process-primary-selection',
+};
+export default SettingsFields;


### PR DESCRIPTION
Fixes #145.

Most changes just follow the [Official Porting Guide](https://gjs.guide/extensions/upgrading/gnome-shell-45.html). Additionally, the following changes are necessary:

- Replace `Mainloop.*` calls with equivalent `GLib.*` calls
- Replace some global variables with class fields
- Extract settings keys into a separate module so the can be imported by both the extension and the preferences
- Wrap preferences in a Adw.PreferencesPage and Adw.PreferencesGroup

While testing on my main machine (Fedora 39 Beta) using a nested instance of GNOME Shell, I ran into multiple database corruptions, but I couldn't replicate this issue in a GNOME OS VM.  I also don't see how this can be caused by these changes.

Since these changes aren't compatible with GNOME <45, it would make sense to create a final release for these versions before merging this PR.