### PR TITLE
Set search entry width to avoid overflowing menu

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -112,7 +112,7 @@ class ClipboardIndicator extends PanelMenu.Button {
   _buildMenu() {
     this.searchEntry = new St.Entry({
       name: 'searchEntry',
-      style_class: 'search-entry',
+      style_class: 'search-entry ci-history-search-entry',
       can_focus: true,
       hint_text: _('Search clipboard history…'),
       track_hover: true,

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -28,3 +28,7 @@
 .ci-history-actions-section .popup-menu-ornament {
   width: auto;
 }
+
+.ci-history-search-entry {
+  width: 5em;
+}


### PR DESCRIPTION
This sets the search entry width to `5em` to fix issue #139. The style class `search-entry` has a width of `24em` as you can see [here](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/data/theme/gnome-shell-sass/widgets/_search-entry.scss?ref_type=heads#L6).