### PR TITLE
Set ornament to none in new history items

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -371,6 +371,7 @@ class ClipboardIndicator extends PanelMenu.Button {
     }
 
     const menuItem = new PopupMenu.PopupMenuItem('', { hover: false });
+    menuItem.setOrnament(PopupMenu.Ornament.NONE);
 
     menuItem.entry = entry;
     entry.menuItem = menuItem;


### PR DESCRIPTION
This fixes the misalignment in history menu items that are restored from log. The default ornament for new `PopupMenuItem` is hidden as you can see [here](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js?ref_type=heads#L100). 

| Before | After |
|----------|--------|
| ![Screenshot from 2023-11-14 10-22-19](https://github.com/SUPERCILEX/gnome-clipboard-history/assets/4119508/ffcb8098-f88d-41b9-bc43-84a192642695) | ![Screenshot from 2023-11-14 10-23-05](https://github.com/SUPERCILEX/gnome-clipboard-history/assets/4119508/d6182ece-4cb9-455f-9396-df828aa7ca8f) |
