### PR TITLE
Add option for ignoring specific mime type

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -850,6 +850,7 @@ class ClipboardIndicator extends PanelMenu.Button {
         'x-kde-passwordManagerHint',
       )
     ) {
+      log(this.uuid, 'Ignoring password entry.');
       return;
     }
 
@@ -869,6 +870,7 @@ class ClipboardIndicator extends PanelMenu.Button {
         'x-kde-passwordManagerHint',
       )
     ) {
+      log(this.uuid, 'Ignoring password entry.');
       return;
     }
 

--- a/extension.js
+++ b/extension.js
@@ -839,18 +839,28 @@ class ClipboardIndicator extends PanelMenu.Button {
     }
   }
 
-  _queryClipboard() {
+  _shouldAbortClipboardQuery(kind) {
     if (PRIVATE_MODE) {
-      return;
+      return true;
     }
 
     if (
       IGNORE_PASSWORD_MIMES &&
-      Clipboard.get_mimetypes(St.Clipboard.CLIPBOARD).includes(
+      Clipboard.get_mimetypes(kind).includes(
+        // Note that we should check for the value "secret" but there don't appear to be any other
+        // values so it's not worth the trouble right now.
         'x-kde-passwordManagerHint',
       )
     ) {
       log(this.uuid, 'Ignoring password entry.');
+      return true;
+    }
+
+    return false;
+  }
+
+  _queryClipboard() {
+    if (this._shouldAbortClipboardQuery(St.Clipboard.CLIPBOARD)) {
       return;
     }
 
@@ -860,17 +870,7 @@ class ClipboardIndicator extends PanelMenu.Button {
   }
 
   _queryPrimaryClipboard() {
-    if (PRIVATE_MODE) {
-      return;
-    }
-
-    if (
-      IGNORE_PASSWORD_MIMES &&
-      Clipboard.get_mimetypes(St.Clipboard.PRIMARY).includes(
-        'x-kde-passwordManagerHint',
-      )
-    ) {
-      log(this.uuid, 'Ignoring password entry.');
+    if (this._shouldAbortClipboardQuery(St.Clipboard.PRIMARY)) {
       return;
     }
 

--- a/extension.js
+++ b/extension.js
@@ -60,6 +60,7 @@ let DISABLE_DOWN_ARROW;
 let STRIP_TEXT;
 let PASTE_ON_SELECTION;
 let PROCESS_PRIMARY_SELECTION;
+let IGNORE_MIMETYPE;
 
 class ClipboardIndicator extends PanelMenu.Button {
   _init(extension) {
@@ -843,6 +844,14 @@ class ClipboardIndicator extends PanelMenu.Button {
       return;
     }
 
+    var glist = Clipboard.get_mimetypes(St.Clipboard.CLIPBOARD);
+    if(IGNORE_MIMETYPE !== '' && glist.includes(IGNORE_MIMETYPE)){
+      if(NOTIFY_ON_COPY){
+        this._showNotification(_('Found evil mime type; didn\'t copy'), null, (notif) => {});
+      }
+     return;
+    }
+
     Clipboard.get_text(St.ClipboardType.CLIPBOARD, (_, text) => {
       this._processClipboardContent(text, true);
     });
@@ -851,6 +860,14 @@ class ClipboardIndicator extends PanelMenu.Button {
   _queryPrimaryClipboard() {
     if (PRIVATE_MODE) {
       return;
+    }
+
+    var glist = Clipboard.get_mimetypes(St.Clipboard.PRIMARY);
+    if(IGNORE_MIMETYPE !== '' && glist.includes(IGNORE_MIMETYPE)){
+      if(NOTIFY_ON_COPY){
+        this._showNotification(_('Found evil mime type; didn\'t copy'), null, (notif) => {});
+      }
+     return;
     }
 
     Clipboard.get_text(St.ClipboardType.PRIMARY, (_, text) => {
@@ -1112,6 +1129,9 @@ class ClipboardIndicator extends PanelMenu.Button {
     );
     PROCESS_PRIMARY_SELECTION = this.settings.get_boolean(
       SettingsFields.PROCESS_PRIMARY_SELECTION,
+    );
+    IGNORE_MIMETYPE = this.settings.get_string(
+      SettingsFields.IGNORE_MIMETYPE,
     );
   }
 

--- a/extension.js
+++ b/extension.js
@@ -853,33 +853,36 @@ class ClipboardIndicator extends PanelMenu.Button {
       const mimecontent = "secret";
 
       if(glist.includes(mimetype)){
-          var res = await new Promise((resolve, reject) => {
-            Clipboard.get_content(St.Clipboard.CLIPBOARD,mimetype, (a, text) => {
-
+          await new Promise((resolve, reject) => {
+            Clipboard.get_content(St.Clipboard.CLIPBOARD,mimetype, (clipboardType, text) => {
               const data = text.get_data();
               const encodedString = new TextEncoder("utf-8").encode(mimecontent);
-
-              let matches = true;
+      
               if (data.length === encodedString.length){
-                for (let i = 0; i < data.length; i++) {
-                  if (data[i] !== encodedString[i]) {
-                      matches =  false;
-                  }
-                }
+                resolve(data.every((e, i) => {
+                  return e === encodedString[i];
+                }));
               }
               else {
-                matches = false;
-              }
-              resolve(matches);
+                resolve(false);
+              }       
             });
-          });
-          discardCurrentCurrent = res;
+            // Reject automatically if nothing was returned after 5 seconds;
+            setTimeout(() => {reject("Nothing returned from the clipboard");}, 5000);
+          }).then(
+            (resolvevalue) => {discardCurrent = resolvevalue;},
+            (rejectval) => {console.error(rejectval);}
+          );
       }
+
       if (discardCurrent){
+        //PRIVATE_MODE = true;
+        //this._updatePrivateModeState();
         return;
       }
       else {
-        console.error("Dont ignore");
+        //PRIVATE_MODE = false;
+        //this._updatePrivateModeState();
       }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Clipboard History",
-  "version": 43,
+  "version": 38,
   "uuid": "clipboard-history@alexsaveau.dev",
   "gettext-domain": "clipboard-history@alexsaveau.dev",
   "settings-schema": "org.gnome.shell.extensions.clipboard-history",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Clipboard History",
-  "version": 38,
+  "version": 43,
   "uuid": "clipboard-history@alexsaveau.dev",
   "gettext-domain": "clipboard-history@alexsaveau.dev",
   "settings-schema": "org.gnome.shell.extensions.clipboard-history",

--- a/prefs.js
+++ b/prefs.js
@@ -71,7 +71,7 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
     const field_strip_text = new Gtk.Switch();
     const field_paste_on_selection = new Gtk.Switch();
     const field_process_primary_selection = new Gtk.Switch();
-    const field_ignore_mimetype = new Gtk.Entry();
+    const field_discard_password_mimes = new Gtk.Switch();
     const field_move_item_first = new Gtk.Switch();
     const field_keybinding = createKeybindingWidget(settings);
     addKeybinding(
@@ -180,8 +180,8 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
       hexpand: true,
       halign: Gtk.Align.START,
     });
-    const ignoreMimeType = new Gtk.Label({
-      label: _('Ignore entry marked with MIME-Type'),
+    const discardPasswordMimes = new Gtk.Label({
+      label: _('Try ignoring entries from Password-Managers'),
       hexpand: true,
       halign: Gtk.Align.START,
     })
@@ -217,7 +217,7 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
     addRow(stripTextLabel, field_strip_text);
     addRow(pasteOnSelectionLabel, field_paste_on_selection);
     addRow(processPrimarySelection, field_process_primary_selection);
-    addRow(ignoreMimeType, field_ignore_mimetype);
+    addRow(discardPasswordMimes, field_discard_password_mimes);
     addRow(displayModeLabel, field_display_mode);
     addRow(disableDownArrowLabel, field_disable_down_arrow);
     addRow(topbarPreviewLabel, field_topbar_preview_size);
@@ -305,9 +305,9 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
       Gio.SettingsBindFlags.DEFAULT,
     );
     settings.bind(
-      Fields.IGNORE_MIMETYPE,
-      field_ignore_mimetype,
-      'text',
+      Fields.DISCARD_PASSWORD_MIMES,
+      field_discard_password_mimes,
+      'active',
       Gio.SettingsBindFlags.DEFAULT,
     )
     settings.bind(

--- a/prefs.js
+++ b/prefs.js
@@ -71,6 +71,7 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
     const field_strip_text = new Gtk.Switch();
     const field_paste_on_selection = new Gtk.Switch();
     const field_process_primary_selection = new Gtk.Switch();
+    const field_ignore_mimetype = new Gtk.Entry();
     const field_move_item_first = new Gtk.Switch();
     const field_keybinding = createKeybindingWidget(settings);
     addKeybinding(
@@ -179,6 +180,11 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
       hexpand: true,
       halign: Gtk.Align.START,
     });
+    const ignoreMimeType = new Gtk.Label({
+      label: _('Ignore entry marked with MIME-Type'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    })
 
     const addRow = ((main) => {
       let row = 0;
@@ -211,6 +217,7 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
     addRow(stripTextLabel, field_strip_text);
     addRow(pasteOnSelectionLabel, field_paste_on_selection);
     addRow(processPrimarySelection, field_process_primary_selection);
+    addRow(ignoreMimeType, field_ignore_mimetype);
     addRow(displayModeLabel, field_display_mode);
     addRow(disableDownArrowLabel, field_disable_down_arrow);
     addRow(topbarPreviewLabel, field_topbar_preview_size);
@@ -297,6 +304,12 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );
+    settings.bind(
+      Fields.IGNORE_MIMETYPE,
+      field_ignore_mimetype,
+      'text',
+      Gio.SettingsBindFlags.DEFAULT,
+    )
     settings.bind(
       Fields.ENABLE_KEYBINDING,
       field_keybinding_activation,

--- a/prefs.js
+++ b/prefs.js
@@ -71,7 +71,7 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
     const field_strip_text = new Gtk.Switch();
     const field_paste_on_selection = new Gtk.Switch();
     const field_process_primary_selection = new Gtk.Switch();
-    const field_discard_password_mimes = new Gtk.Switch();
+    const field_ignore_password_mimes = new Gtk.Switch();
     const field_move_item_first = new Gtk.Switch();
     const field_keybinding = createKeybindingWidget(settings);
     addKeybinding(
@@ -180,11 +180,11 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
       hexpand: true,
       halign: Gtk.Align.START,
     });
-    const discardPasswordMimes = new Gtk.Label({
-      label: _('Try ignoring entries from Password-Managers'),
+    const ignorePasswordMimes = new Gtk.Label({
+      label: _('Try to avoid copying passwords (known potentially buggy)'),
       hexpand: true,
       halign: Gtk.Align.START,
-    })
+    });
 
     const addRow = ((main) => {
       let row = 0;
@@ -217,7 +217,7 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
     addRow(stripTextLabel, field_strip_text);
     addRow(pasteOnSelectionLabel, field_paste_on_selection);
     addRow(processPrimarySelection, field_process_primary_selection);
-    addRow(discardPasswordMimes, field_discard_password_mimes);
+    addRow(ignorePasswordMimes, field_ignore_password_mimes);
     addRow(displayModeLabel, field_display_mode);
     addRow(disableDownArrowLabel, field_disable_down_arrow);
     addRow(topbarPreviewLabel, field_topbar_preview_size);
@@ -305,11 +305,11 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
       Gio.SettingsBindFlags.DEFAULT,
     );
     settings.bind(
-      Fields.DISCARD_PASSWORD_MIMES,
-      field_discard_password_mimes,
+      Fields.IGNORE_PASSWORD_MIMES,
+      field_ignore_password_mimes,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
-    )
+    );
     settings.bind(
       Fields.ENABLE_KEYBINDING,
       field_keybinding_activation,

--- a/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
@@ -132,9 +132,9 @@
       <default><![CDATA[['<Super><Shift>P']]]></default>
       <summary>Toggle private mode</summary>
     </key>
-    <key name="ignore-mimetype" type="s">
-      <default>'your-mime-type-not-to-be-recorded'</default>
-      <summary>MIME-Type not to be recorded</summary>
+    <key name="discard-password-mimes" type="b">
+      <default>true</default>
+      <summary>Filter password-managers</summary>
     </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
@@ -132,9 +132,9 @@
       <default><![CDATA[['<Super><Shift>P']]]></default>
       <summary>Toggle private mode</summary>
     </key>
-    <key name="discard-password-mimes" type="b">
+    <key name="ignore-password-mimes" type="b">
       <default>true</default>
-      <summary>Filter password-managers</summary>
+      <summary>Ignore selections containing the x-kde-passwordManagerHint mime type.</summary>
     </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
@@ -132,5 +132,9 @@
       <default><![CDATA[['<Super><Shift>P']]]></default>
       <summary>Toggle private mode</summary>
     </key>
+    <key name="ignore-mimetype" type="s">
+      <default>'your-mime-type-not-to-be-recorded'</default>
+      <summary>MIME-Type not to be recorded</summary>
+    </key>
   </schema>
 </schemalist>

--- a/settingsFields.js
+++ b/settingsFields.js
@@ -14,6 +14,6 @@ const SettingsFields = {
   PRIVATE_MODE: 'private-mode',
   PASTE_ON_SELECTION: 'paste-on-selection',
   PROCESS_PRIMARY_SELECTION: 'process-primary-selection',
-  IGNORE_MIMETYPE: 'ignore-mimetype',
+  DISCARD_PASSWORD_MIMES: 'discard-password-mimes'
 };
 export default SettingsFields;

--- a/settingsFields.js
+++ b/settingsFields.js
@@ -14,6 +14,6 @@ const SettingsFields = {
   PRIVATE_MODE: 'private-mode',
   PASTE_ON_SELECTION: 'paste-on-selection',
   PROCESS_PRIMARY_SELECTION: 'process-primary-selection',
-  DISCARD_PASSWORD_MIMES: 'discard-password-mimes'
+  IGNORE_PASSWORD_MIMES: 'ignore-password-mimes',
 };
 export default SettingsFields;

--- a/settingsFields.js
+++ b/settingsFields.js
@@ -14,5 +14,6 @@ const SettingsFields = {
   PRIVATE_MODE: 'private-mode',
   PASTE_ON_SELECTION: 'paste-on-selection',
   PROCESS_PRIMARY_SELECTION: 'process-primary-selection',
+  IGNORE_MIMETYPE: 'ignore-mimetype',
 };
 export default SettingsFields;


### PR DESCRIPTION
Addresses #92 

Some Password-managers like KeePassXC just pin on an additional MIME-Type (the type "x-kde-passwordManagerHint") to mark the current clipboard-content as sensitive. 
I quickly created a small mockup of a setting that allows the user to specify such a type, which is to be ignored.
In short it just calls [get_mimetypes](https://gjs-docs.gnome.org/st14~14/st.clipboard#method-get_mimetypes) on the clipboard and checks if the returned array contains the user-specified type.

It works for me in this state.
It is still very unpolished yet, and the hard work (like translations, testing) is still missing. 
I would like to add a button to overwrite the decision to ignore the clipboard to the notification as well.
What do you think about the approach of filtering MIME-Types in general?

I am also a little bit unsure about the repo structure and the way the pre-45-branch is handled in contrast to master, please tell me if I did something wrong ^^