### PR TITLE
Update metadata.json to support GS 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,10 @@
 {
   "name": "Clipboard History",
-  "version": 44,
+  "version": 45,
   "uuid": "clipboard-history@alexsaveau.dev",
   "gettext-domain": "clipboard-history@alexsaveau.dev",
   "settings-schema": "org.gnome.shell.extensions.clipboard-history",
   "description": "Gnome Clipboard History is a clipboard manager GNOME extension that saves items you've copied into an easily accessible, searchable history panel.",
   "url": "https://github.com/SUPERCILEX/gnome-clipboard-history",
-  "shell-version": ["46"]
+  "shell-version": ["46", "47"]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Clipboard History",
-  "version": 45,
+  "version": 44
   "uuid": "clipboard-history@alexsaveau.dev",
   "gettext-domain": "clipboard-history@alexsaveau.dev",
   "settings-schema": "org.gnome.shell.extensions.clipboard-history",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Clipboard History",
-  "version": 44
+  "version": 44,
   "uuid": "clipboard-history@alexsaveau.dev",
   "gettext-domain": "clipboard-history@alexsaveau.dev",
   "settings-schema": "org.gnome.shell.extensions.clipboard-history",


### PR DESCRIPTION
This only bumps the metadata, it seems to be working fine on GS 47.