### PR TITLE
Update metadata.json to support GS49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,5 +6,5 @@
   "settings-schema": "org.gnome.shell.extensions.clipboard-history",
   "description": "Gnome Clipboard History is a clipboard manager GNOME extension that saves items you've copied into an easily accessible, searchable history panel.",
   "url": "https://github.com/SUPERCILEX/gnome-clipboard-history",
-  "shell-version": ["46", "47", "48"]
+  "shell-version": ["46", "47", "48", "49"]
 }


### PR DESCRIPTION
I have already tested it on Arch Linux with GNOME 49. No APIs were broken, and it can be adapted simply by modifying the metadata.