### PR TITLE
Add type-ahead search handling

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -61,6 +61,7 @@ let STRIP_TEXT;
 let PASTE_ON_SELECTION;
 let PROCESS_PRIMARY_SELECTION;
 let IGNORE_PASSWORD_MIMES;
+let ENABLE_TYPEAHEAD_SEARCH;
 
 class ClipboardIndicator extends PanelMenu.Button {
   _init(extension) {
@@ -369,6 +370,10 @@ class ClipboardIndicator extends PanelMenu.Button {
   }
 
   _handleSearchTypeAheadKeyEvent(event) {
+    if (!ENABLE_TYPEAHEAD_SEARCH) {
+      return false;
+    }
+
     if (global.stage.get_key_focus() === this.searchEntry) {
       return false;
     }
@@ -1186,6 +1191,9 @@ class ClipboardIndicator extends PanelMenu.Button {
     );
     IGNORE_PASSWORD_MIMES = this.settings.get_boolean(
       SettingsFields.IGNORE_PASSWORD_MIMES,
+    );
+    ENABLE_TYPEAHEAD_SEARCH = this.settings.get_boolean(
+      SettingsFields.ENABLE_TYPEAHEAD_SEARCH,
     );
   }
 

--- a/extension.js
+++ b/extension.js
@@ -303,10 +303,13 @@ class ClipboardIndicator extends PanelMenu.Button {
   }
 
   _handleGlobalKeyEvent(event) {
-    this._handleCtrlSelectKeyEvent(event);
-    this._handleSettingsKeyEvent(event);
-    this._handleNavigationKeyEvent(event);
-    this._handleFocusSearchKeyEvent(event);
+    return (
+      this._handleCtrlSelectKeyEvent(event) ||
+      this._handleSettingsKeyEvent(event) ||
+      this._handleNavigationKeyEvent(event) ||
+      this._handleFocusSearchKeyEvent(event) ||
+      this._handleSearchTypeAheadKeyEvent(event)
+    );
   }
 
   _handleCtrlSelectKeyEvent(event) {
@@ -328,6 +331,7 @@ class ClipboardIndicator extends PanelMenu.Button {
     }
 
     this._onMenuItemSelectedAndMenuClose(items[index - 1]);
+    return true;
   }
 
   _handleSettingsKeyEvent(event) {
@@ -336,6 +340,7 @@ class ClipboardIndicator extends PanelMenu.Button {
     }
 
     this._openSettings();
+    return true;
   }
 
   _handleNavigationKeyEvent(event) {
@@ -347,7 +352,11 @@ class ClipboardIndicator extends PanelMenu.Button {
       this._navigateNextPage();
     } else if (event.get_key_unicode() === 'p') {
       this._navigatePrevPage();
+    } else {
+      return;
     }
+
+    return true;
   }
 
   _handleFocusSearchKeyEvent(event) {
@@ -356,6 +365,47 @@ class ClipboardIndicator extends PanelMenu.Button {
     }
 
     global.stage.set_key_focus(this.searchEntry);
+    return true;
+  }
+
+  _handleSearchTypeAheadKeyEvent(event) {
+    if (global.stage.get_key_focus() === this.searchEntry) {
+      return false;
+    }
+
+    if (
+      event.has_control_modifier() ||
+      event.has_alt_modifier?.() ||
+      event.has_super_modifier?.()
+    ) {
+      return false;
+    }
+
+    const keySymbol = event.get_key_symbol();
+    if (keySymbol === Clutter.KEY_BackSpace) {
+      const currentText = this.searchEntry.get_text();
+      if (!currentText) {
+        return false;
+      }
+
+      global.stage.set_key_focus(this.searchEntry);
+      this.searchEntry.set_text(currentText.slice(0, -1));
+      return true;
+    }
+
+    const unicode = event.get_key_unicode();
+    if (!unicode || unicode.length !== 1) {
+      return false;
+    }
+
+    const codePoint = unicode.charCodeAt(0);
+    if (codePoint < 32 || codePoint === 127) {
+      return false;
+    }
+
+    global.stage.set_key_focus(this.searchEntry);
+    this.searchEntry.set_text(this.searchEntry.get_text() + unicode);
+    return true;
   }
 
   _addEntry(entry, selectEntry, updateClipboard, insertIndex) {

--- a/prefs.js
+++ b/prefs.js
@@ -72,6 +72,7 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
     const field_paste_on_selection = new Gtk.Switch();
     const field_process_primary_selection = new Gtk.Switch();
     const field_ignore_password_mimes = new Gtk.Switch();
+    const field_enable_typeahead_search = new Gtk.Switch();
     const field_move_item_first = new Gtk.Switch();
     const field_keybinding = createKeybindingWidget(settings);
     addKeybinding(
@@ -185,6 +186,11 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
       hexpand: true,
       halign: Gtk.Align.START,
     });
+    const enableTypeAheadSearch = new Gtk.Label({
+      label: _('Enable type-ahead search in menu'),
+      hexpand: true,
+      halign: Gtk.Align.START,
+    });
 
     const addRow = ((main) => {
       let row = 0;
@@ -218,6 +224,7 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
     addRow(pasteOnSelectionLabel, field_paste_on_selection);
     addRow(processPrimarySelection, field_process_primary_selection);
     addRow(ignorePasswordMimes, field_ignore_password_mimes);
+    addRow(enableTypeAheadSearch, field_enable_typeahead_search);
     addRow(displayModeLabel, field_display_mode);
     addRow(disableDownArrowLabel, field_disable_down_arrow);
     addRow(topbarPreviewLabel, field_topbar_preview_size);
@@ -307,6 +314,12 @@ export default class ClipboardHistoryPrefs extends ExtensionPreferences {
     settings.bind(
       Fields.IGNORE_PASSWORD_MIMES,
       field_ignore_password_mimes,
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    settings.bind(
+      Fields.ENABLE_TYPEAHEAD_SEARCH,
+      field_enable_typeahead_search,
       'active',
       Gio.SettingsBindFlags.DEFAULT,
     );

--- a/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.clipboard-indicator.gschema.xml
@@ -136,5 +136,13 @@
       <default>true</default>
       <summary>Ignore selections containing the x-kde-passwordManagerHint mime type.</summary>
     </key>
+
+    <key name="enable-typeahead-search" type="b">
+      <default>false</default>
+      <summary>Enable type-ahead search in the menu</summary>
+      <description>
+        If true, typing in the open menu focuses the search entry and appends typed characters.
+      </description>
+    </key>
   </schema>
 </schemalist>

--- a/settingsFields.js
+++ b/settingsFields.js
@@ -15,5 +15,6 @@ const SettingsFields = {
   PASTE_ON_SELECTION: 'paste-on-selection',
   PROCESS_PRIMARY_SELECTION: 'process-primary-selection',
   IGNORE_PASSWORD_MIMES: 'ignore-password-mimes',
+  ENABLE_TYPEAHEAD_SEARCH: 'enable-typeahead-search',
 };
 export default SettingsFields;


### PR DESCRIPTION
Adds type-ahead search to the clipboard menu: when the search field is not focused and the user starts typing, focus moves to search and the typed characters are inserted immediately. This also keeps the existing keyboard shortcuts working by returning handled key events consistently.